### PR TITLE
fix primary key too restrictive

### DIFF
--- a/bot/ext/teams.py
+++ b/bot/ext/teams.py
@@ -49,10 +49,11 @@ class TeamUserEditView(dui.View):
                         server member"
                 )
 
+            await self.team.add_member(member)
+
             if member.get_role(self.team.member_role_id) is not None:
                 continue
 
-            await self.team.add_member(member)
             await member.add_roles(
                 discord.Object(self.team.member_role_id), reason="add to team"
             )
@@ -73,10 +74,11 @@ class TeamUserEditView(dui.View):
                         server member"
                 )
 
+            await self.team.remove_member(member)
+
             if member.get_role(self.team.member_role_id) is None:
                 continue
 
-            await self.team.remove_member(member)
             await member.remove_roles(
                 discord.Object(self.team.member_role_id),
                 reason="remove from team",

--- a/migrations/v2_team_member_pk_fix.sql
+++ b/migrations/v2_team_member_pk_fix.sql
@@ -1,0 +1,3 @@
+
+ALTER TABLE team_member DROP CONSTRAINT team_member_pkey;
+ALTER TABLE team_member ADD CONSTRAINT team_member_pkey PRIMARY KEY (team_id, user_id);


### PR DESCRIPTION
The primary key on the team_member table was set up incorrectly which only allowed one member per team.